### PR TITLE
wip: detect aks cluster name

### DIFF
--- a/.chloggen/resourcedetectionprocessor-azure-cluster-name.yaml
+++ b/.chloggen/resourcedetectionprocessor-azure-cluster-name.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: processor/resourcedetectionprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Detect Azure cluster name from IMDS metadata
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [26794]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/internal/metadataproviders/azure/metadata.go
+++ b/internal/metadataproviders/azure/metadata.go
@@ -85,8 +85,6 @@ func (p *azureProviderImpl) Metadata(ctx context.Context) (*ComputeMetadata, err
 		return nil, fmt.Errorf("failed to read Azure IMDS reply: %w", err)
 	}
 
-	fmt.Println(string(respBody))
-
 	var metadata *ComputeMetadata
 	err = json.Unmarshal(respBody, &metadata)
 	if err != nil {

--- a/internal/metadataproviders/azure/metadata.go
+++ b/internal/metadataproviders/azure/metadata.go
@@ -85,6 +85,8 @@ func (p *azureProviderImpl) Metadata(ctx context.Context) (*ComputeMetadata, err
 		return nil, fmt.Errorf("failed to read Azure IMDS reply: %w", err)
 	}
 
+	fmt.Println(string(respBody))
+
 	var metadata *ComputeMetadata
 	err = json.Unmarshal(respBody, &metadata)
 	if err != nil {

--- a/processor/resourcedetectionprocessor/README.md
+++ b/processor/resourcedetectionprocessor/README.md
@@ -412,11 +412,31 @@ processors:
 
 #### Cluster Name
 
+Cluster name detection is disabled by default, and can be enabled with the
+following configuration:
+
+```yaml
+processors:
+  resourcedetection/aks:
+    detectors: [aks]
+    timeout: 2s
+    override: false
+    aks:
+      resource_attributes:
+        k8s.cluster.name: true
+```
+
 Azure AKS cluster name is derived from the Azure Instance Metadata Service's (IMDS) infrastructure resource group field. This field contains the resource group and name of the cluster, separated by underscores. e.g: `MC_<resource group>_<cluster name>_<location>`.
 
-The cluster name is accurately detected if underscores are not present in the resource group name or the cluster name.
+Example:
+  - Resource group: my-resource-group
+  - Cluster name:   my-cluster
+  - Location:       eastus
+  - Generated name: MC_my-resource-group_my-cluster_eastus
 
-If accurate parsing cannot be performed, the infrastructure resource group value is returned. This value can be used to accurately identify the cluster, as Azure will not allow users to create multiple clusters with the same infrastructure resource group.
+The cluster name is detected if it does not contain underscores and if a custom infrastructure resource group name was not used.
+
+If accurate parsing cannot be performed, the infrastructure resource group value is returned. This value can be used to uniquely identify the cluster, as Azure will not allow users to create multiple clusters with the same infrastructure resource group name.
 
 ### Consul
 

--- a/processor/resourcedetectionprocessor/README.md
+++ b/processor/resourcedetectionprocessor/README.md
@@ -410,6 +410,14 @@ processors:
     override: false
 ```
 
+#### Cluster Name
+
+Azure AKS cluster name is derived from the Azure Instance Metadata Service's (IMDS) infrastructure resource group field. This field contains the resource group and name of the cluster, separated by underscores. e.g: `MC_<resource group>_<cluster name>_<location>`.
+
+The cluster name is accurately detected if underscores are not present in the resource group name or the cluster name.
+
+If accurate parsing cannot be performed, the infrastructure resource group value is returned. This value can be used to accurately identify the cluster, as Azure will not allow users to create multiple clusters with the same infrastructure resource group.
+
 ### Consul
 
 Queries a [consul agent](https://www.consul.io/docs/agent) and reads its' [configuration endpoint](https://www.consul.io/api-docs/agent#read-configuration) to retrieve the following resource attributes:

--- a/processor/resourcedetectionprocessor/README.md
+++ b/processor/resourcedetectionprocessor/README.md
@@ -400,6 +400,7 @@ processors:
 
   * cloud.provider ("azure")
   * cloud.platform ("azure_aks")
+  * k8s.cluster.name
 
 ```yaml
 processors:

--- a/processor/resourcedetectionprocessor/internal/azure/aks/aks.go
+++ b/processor/resourcedetectionprocessor/internal/azure/aks/aks.go
@@ -55,14 +55,13 @@ func (d *Detector) Detect(ctx context.Context) (resource pcommon.Resource, schem
 	}
 	if d.resourceAttributes.CloudPlatform.Enabled {
 		attrs.PutStr(conventions.AttributeCloudPlatform, conventions.AttributeCloudPlatformAzureAKS)
-
-		if d.resourceAttributes.K8sClusterName.Enabled {
-			m, err := d.provider.Metadata(ctx)
-			if err != nil {
-				return res, "", fmt.Errorf("failed to get IMDS metadata: %w", err)
-			}
-			attrs.PutStr(conventions.AttributeK8SClusterName, parseClusterName(m.ResourceGroupName))
+	}
+	if d.resourceAttributes.K8sClusterName.Enabled {
+		m, err := d.provider.Metadata(ctx)
+		if err != nil {
+			return res, "", fmt.Errorf("failed to get IMDS metadata: %w", err)
 		}
+		attrs.PutStr(conventions.AttributeK8SClusterName, parseClusterName(m.ResourceGroupName))
 	}
 
 	return res, conventions.SchemaURL, nil

--- a/processor/resourcedetectionprocessor/internal/azure/aks/aks_test.go
+++ b/processor/resourcedetectionprocessor/internal/azure/aks/aks_test.go
@@ -69,25 +69,48 @@ func mockProvider() *azure.MockProvider {
 
 func TestParseClusterName(t *testing.T) {
 	cases := []struct {
-		name     string
-		input    string
-		expected string
+		name          string
+		resourceGroup string
+		expected      string
 	}{
 		{
-			name:     "parses cluster name",
-			input:    "MC_myResourceGroup_myAKSCluster_eastus",
-			expected: "myAKSCluster",
+			name:          "Return cluster name",
+			resourceGroup: "MC_myResourceGroup_AKSCluster_eastus",
+			expected:      "AKSCluster",
 		},
 		{
-			name:     "returns resource group when cluster name has underscores",
-			input:    "MC_myResourceGroup_my_AKS_Cluster_eastus",
-			expected: "MC_myResourceGroup_my_AKS_Cluster_eastus",
+			name:          "Return resource group name, resource group contains underscores",
+			resourceGroup: "MC_Resource_Group_AKSCluster_eastus",
+			expected:      "MC_Resource_Group_AKSCluster_eastus",
+		},
+		{
+			name:          "Return resource group name, cluster name contains underscores",
+			resourceGroup: "MC_myResourceGroup_AKS_Cluster_eastus",
+			expected:      "MC_myResourceGroup_AKS_Cluster_eastus",
+		},
+		{
+			name:          "Custom infrastructure resource group name, return resource group name",
+			resourceGroup: "infra-group_name",
+			expected:      "infra-group_name",
+		},
+		{
+			name:          "Custom infrastructure resource group name with four underscores, return resource group name",
+			resourceGroup: "dev_infra_group_name",
+			expected:      "dev_infra_group_name",
+		},
+		// This case is unlikely because it would require the user to create
+		// a custom infrastructure resource group with the MC prefix and the
+		// correct number of underscores.
+		{
+			name:          "Custom infrastructure resource group name with MC prefix",
+			resourceGroup: "MC_group_name_location",
+			expected:      "name",
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := parseClusterName(tc.input)
+			actual := parseClusterName(tc.resourceGroup)
 			assert.Equal(t, tc.expected, actual)
 		})
 	}

--- a/processor/resourcedetectionprocessor/internal/azure/aks/internal/metadata/generated_config.go
+++ b/processor/resourcedetectionprocessor/internal/azure/aks/internal/metadata/generated_config.go
@@ -2,9 +2,25 @@
 
 package metadata
 
+import "go.opentelemetry.io/collector/confmap"
+
 // ResourceAttributeConfig provides common config for a particular resource attribute.
 type ResourceAttributeConfig struct {
 	Enabled bool `mapstructure:"enabled"`
+
+	enabledSetByUser bool
+}
+
+func (rac *ResourceAttributeConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+	err := parser.Unmarshal(rac, confmap.WithErrorUnused())
+	if err != nil {
+		return err
+	}
+	rac.enabledSetByUser = parser.IsSet("enabled")
+	return nil
 }
 
 // ResourceAttributesConfig provides config for resourcedetectionprocessor/aks resource attributes.

--- a/processor/resourcedetectionprocessor/internal/azure/aks/internal/metadata/generated_config.go
+++ b/processor/resourcedetectionprocessor/internal/azure/aks/internal/metadata/generated_config.go
@@ -2,31 +2,16 @@
 
 package metadata
 
-import "go.opentelemetry.io/collector/confmap"
-
 // ResourceAttributeConfig provides common config for a particular resource attribute.
 type ResourceAttributeConfig struct {
 	Enabled bool `mapstructure:"enabled"`
-
-	enabledSetByUser bool
-}
-
-func (rac *ResourceAttributeConfig) Unmarshal(parser *confmap.Conf) error {
-	if parser == nil {
-		return nil
-	}
-	err := parser.Unmarshal(rac, confmap.WithErrorUnused())
-	if err != nil {
-		return err
-	}
-	rac.enabledSetByUser = parser.IsSet("enabled")
-	return nil
 }
 
 // ResourceAttributesConfig provides config for resourcedetectionprocessor/aks resource attributes.
 type ResourceAttributesConfig struct {
-	CloudPlatform ResourceAttributeConfig `mapstructure:"cloud.platform"`
-	CloudProvider ResourceAttributeConfig `mapstructure:"cloud.provider"`
+	CloudPlatform  ResourceAttributeConfig `mapstructure:"cloud.platform"`
+	CloudProvider  ResourceAttributeConfig `mapstructure:"cloud.provider"`
+	K8sClusterName ResourceAttributeConfig `mapstructure:"k8s.cluster.name"`
 }
 
 func DefaultResourceAttributesConfig() ResourceAttributesConfig {
@@ -35,6 +20,9 @@ func DefaultResourceAttributesConfig() ResourceAttributesConfig {
 			Enabled: true,
 		},
 		CloudProvider: ResourceAttributeConfig{
+			Enabled: true,
+		},
+		K8sClusterName: ResourceAttributeConfig{
 			Enabled: true,
 		},
 	}

--- a/processor/resourcedetectionprocessor/internal/azure/aks/internal/metadata/generated_config_test.go
+++ b/processor/resourcedetectionprocessor/internal/azure/aks/internal/metadata/generated_config_test.go
@@ -25,15 +25,17 @@ func TestResourceAttributesConfig(t *testing.T) {
 		{
 			name: "all_set",
 			want: ResourceAttributesConfig{
-				CloudPlatform: ResourceAttributeConfig{Enabled: true},
-				CloudProvider: ResourceAttributeConfig{Enabled: true},
+				CloudPlatform:  ResourceAttributeConfig{Enabled: true},
+				CloudProvider:  ResourceAttributeConfig{Enabled: true},
+				K8sClusterName: ResourceAttributeConfig{Enabled: true},
 			},
 		},
 		{
 			name: "none_set",
 			want: ResourceAttributesConfig{
-				CloudPlatform: ResourceAttributeConfig{Enabled: false},
-				CloudProvider: ResourceAttributeConfig{Enabled: false},
+				CloudPlatform:  ResourceAttributeConfig{Enabled: false},
+				CloudProvider:  ResourceAttributeConfig{Enabled: false},
+				K8sClusterName: ResourceAttributeConfig{Enabled: false},
 			},
 		},
 	}

--- a/processor/resourcedetectionprocessor/internal/azure/aks/internal/metadata/generated_resource.go
+++ b/processor/resourcedetectionprocessor/internal/azure/aks/internal/metadata/generated_resource.go
@@ -35,6 +35,13 @@ func (rb *ResourceBuilder) SetCloudProvider(val string) {
 	}
 }
 
+// SetK8sClusterName sets provided value as "k8s.cluster.name" attribute.
+func (rb *ResourceBuilder) SetK8sClusterName(val string) {
+	if rb.config.K8sClusterName.Enabled {
+		rb.res.Attributes().PutStr("k8s.cluster.name", val)
+	}
+}
+
 // Emit returns the built resource and resets the internal builder state.
 func (rb *ResourceBuilder) Emit() pcommon.Resource {
 	r := rb.res

--- a/processor/resourcedetectionprocessor/internal/azure/aks/internal/metadata/generated_resource_test.go
+++ b/processor/resourcedetectionprocessor/internal/azure/aks/internal/metadata/generated_resource_test.go
@@ -15,15 +15,16 @@ func TestResourceBuilder(t *testing.T) {
 			rb := NewResourceBuilder(cfg)
 			rb.SetCloudPlatform("cloud.platform-val")
 			rb.SetCloudProvider("cloud.provider-val")
+			rb.SetK8sClusterName("k8s.cluster.name-val")
 
 			res := rb.Emit()
 			assert.Equal(t, 0, rb.Emit().Attributes().Len()) // Second call should return empty Resource
 
 			switch test {
 			case "default":
-				assert.Equal(t, 2, res.Attributes().Len())
+				assert.Equal(t, 3, res.Attributes().Len())
 			case "all_set":
-				assert.Equal(t, 2, res.Attributes().Len())
+				assert.Equal(t, 3, res.Attributes().Len())
 			case "none_set":
 				assert.Equal(t, 0, res.Attributes().Len())
 				return
@@ -40,6 +41,11 @@ func TestResourceBuilder(t *testing.T) {
 			assert.True(t, ok)
 			if ok {
 				assert.EqualValues(t, "cloud.provider-val", val.Str())
+			}
+			val, ok = res.Attributes().Get("k8s.cluster.name")
+			assert.True(t, ok)
+			if ok {
+				assert.EqualValues(t, "k8s.cluster.name-val", val.Str())
 			}
 		})
 	}

--- a/processor/resourcedetectionprocessor/internal/azure/aks/internal/metadata/testdata/config.yaml
+++ b/processor/resourcedetectionprocessor/internal/azure/aks/internal/metadata/testdata/config.yaml
@@ -5,9 +5,13 @@ all_set:
       enabled: true
     cloud.provider:
       enabled: true
+    k8s.cluster.name:
+      enabled: true
 none_set:
   resource_attributes:
     cloud.platform:
       enabled: false
     cloud.provider:
+      enabled: false
+    k8s.cluster.name:
       enabled: false

--- a/processor/resourcedetectionprocessor/internal/azure/aks/metadata.yaml
+++ b/processor/resourcedetectionprocessor/internal/azure/aks/metadata.yaml
@@ -14,4 +14,4 @@ resource_attributes:
   k8s.cluster.name:
     description: The k8s.cluster.name parsed from the Azure Instance Metadata Service's infrastructure resource group field
     type: string
-    enabled: true
+    enabled: false

--- a/processor/resourcedetectionprocessor/internal/azure/aks/metadata.yaml
+++ b/processor/resourcedetectionprocessor/internal/azure/aks/metadata.yaml
@@ -11,3 +11,7 @@ resource_attributes:
     description: The cloud.platform
     type: string
     enabled: true
+  k8s.cluster.name:
+    description: The k8s.cluster.name
+    type: string
+    enabled: true

--- a/processor/resourcedetectionprocessor/internal/azure/aks/metadata.yaml
+++ b/processor/resourcedetectionprocessor/internal/azure/aks/metadata.yaml
@@ -12,6 +12,6 @@ resource_attributes:
     type: string
     enabled: true
   k8s.cluster.name:
-    description: The k8s.cluster.name
+    description: The k8s.cluster.name parsed from the Azure Instance Metadata Service's infrastructure resource group field
     type: string
     enabled: true


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Added best effort support for detecting Azure Kubernetes Service cluster name: `k8s.cluster.name`.

The cluster name can be extracted from the cluster's "resource group name" which is retrieved using existing functionality. The `parseClusterName` function has comments explaining the limitations.

**Link to tracking Issue:** <Issue number if applicable>

https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/26794

**Testing:** <Describe what testing was performed and which tests were added.>

I added unit tests for each scenario, and have tested against live AKS clusters that fit each scenario. I am happy to spin these up if anyone has any questions.

**Documentation:** <Describe the documentation added.>

Added `k8s.cluster.name` to the list of AKS resource attributes.